### PR TITLE
Replace copy-paste with clipboardy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - run: npm ci
@@ -64,9 +61,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -88,9 +82,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -112,9 +103,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -136,9 +124,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -166,9 +151,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -196,9 +178,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -226,9 +205,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -250,9 +226,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -274,9 +247,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - run: npm ci
@@ -300,9 +270,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - run: npm ci
@@ -326,9 +293,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -356,9 +320,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -386,9 +347,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install xvfb
-        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
-        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - run: npm ci
@@ -43,7 +46,7 @@ jobs:
         run: |
           npm run chain &
           sleep 5
-      - run: cd packages/ethernaut-common && npm t
+      - run: cd packages/ethernaut-common && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -61,10 +64,13 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
-      - run: cd packages/ethernaut-util && npm t
+      - run: cd packages/ethernaut-util && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -82,10 +88,13 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
-      - run: cd packages/ethernaut-util-ui && npm t
+      - run: cd packages/ethernaut-util-ui && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -103,10 +112,13 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
-      - run: cd packages/ethernaut-ui && npm t
+      - run: cd packages/ethernaut-ui && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -124,6 +136,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -133,7 +148,7 @@ jobs:
         run: |
           npm run chain &
           sleep 5
-      - run: cd packages/ethernaut-interact && npm t
+      - run: cd packages/ethernaut-interact && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -151,6 +166,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -160,7 +178,7 @@ jobs:
         run: |
           npm run chain &
           sleep 5
-      - run: cd packages/ethernaut-interact-ui && npm t
+      - run: cd packages/ethernaut-interact-ui && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -178,6 +196,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -187,7 +208,7 @@ jobs:
         run: |
           npm run chain &
           sleep 5
-      - run: cd packages/ethernaut-challenges && npm t
+      - run: cd packages/ethernaut-challenges && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -205,10 +226,13 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
-      - run: cd packages/ethernaut-ai && npm t
+      - run: cd packages/ethernaut-ai && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -226,10 +250,13 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
-      - run: cd packages/ethernaut-ai-ui && npm t
+      - run: cd packages/ethernaut-ai-ui && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -247,12 +274,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
-      - run: cd packages/ethernaut-network && npm t
+      - run: cd packages/ethernaut-network && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -270,12 +300,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
-      - run: cd packages/ethernaut-network-ui && npm t
+      - run: cd packages/ethernaut-network-ui && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -293,6 +326,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -302,7 +338,7 @@ jobs:
         run: |
           npm run chain &
           sleep 5
-      - run: cd packages/ethernaut-wallet && npm t
+      - run: cd packages/ethernaut-wallet && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -320,6 +356,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
@@ -329,7 +368,7 @@ jobs:
         run: |
           npm run chain &
           sleep 5
-      - run: cd packages/ethernaut-wallet-ui && npm t
+      - run: cd packages/ethernaut-wallet-ui && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -347,10 +386,13 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install xvfb
+        if: matrix.os == 'ubuntu-latest' && needs.changes.outputs.typescript == 'true'
+        run: sudo apt-get install -y xvfb
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run compile --if-present
-      - run: cd packages/ethernaut-cli && npm t
+      - run: cd packages/ethernaut-cli && xvfb-run npm t
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,6 +3607,25 @@
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true
     },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -4593,6 +4612,127 @@
         "node": ">= 10"
       }
     },
+    "node_modules/clipboardy": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
+      "integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
+      "dependencies": {
+        "arch": "^2.1.1",
+        "execa": "^1.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clipboardy/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/clipboardy/node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clipboardy/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clipboardy/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clipboardy/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clipboardy/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clipboardy/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/clipboardy/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clipboardy/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clipboardy/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -4901,14 +5041,6 @@
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/copy-paste": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/copy-paste/-/copy-paste-1.5.3.tgz",
-      "integrity": "sha512-qOnFo+8l8vemGmdcoCiD7gPTefkXEg2rivYE+EBtuKOj754eFivkGhGAM9e/xqShrpuVE11evSxGnHwVAUK1Iw==",
-      "dependencies": {
-        "iconv-lite": "^0.4.8"
       }
     },
     "node_modules/core-util-is": {
@@ -5324,7 +5456,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -7458,7 +7589,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -7623,7 +7753,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -7640,8 +7769,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -9833,6 +9961,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
     "node_modules/node-abi": {
       "version": "3.56.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
@@ -11234,7 +11367,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12107,6 +12239,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -13657,6 +13798,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -14784,7 +14933,7 @@
       "license": "ISC",
       "dependencies": {
         "chalk": "^2.4.2",
-        "copy-paste": "^1.5.3",
+        "clipboardy": "^2.3.0",
         "openai": "^4.26.0"
       },
       "devDependencies": {
@@ -15159,7 +15308,7 @@
       "license": "ISC",
       "dependencies": {
         "chalk": "^2.4.2",
-        "copy-paste": "^1.5.3",
+        "clipboardy": "^2.3.0",
         "enquirer": "^2.4.1"
       },
       "devDependencies": {

--- a/packages/ethernaut-ai/package.json
+++ b/packages/ethernaut-ai/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^2.4.2",
-    "copy-paste": "^1.5.3",
+    "clipboardy": "2.3.0",
     "openai": "^4.26.0"
   },
   "peerDependencies": {

--- a/packages/ethernaut-ai/src/internal/Action.js
+++ b/packages/ethernaut-ai/src/internal/Action.js
@@ -2,7 +2,7 @@ const debug = require('ethernaut-common/src/ui/debug')
 const chalk = require('chalk')
 const toCliSyntax = require('ethernaut-common/src/ui/syntax')
 const getTaskUsage = require('ethernaut-common/src/tasks/usage')
-const { copy } = require('copy-paste')
+const clipboardy = require('clipboardy')
 
 class Action {
   /**
@@ -105,7 +105,7 @@ class Action {
     let description = ''
 
     const syntax = toCliSyntax(this.task, this.args)
-    copy(syntax)
+    clipboardy.writeSync(syntax)
 
     description += chalk.bold(`${syntax}`)
     description += chalk.dim(' (copied to clipboard)\n')

--- a/packages/ethernaut-ui/package.json
+++ b/packages/ethernaut-ui/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^2.4.2",
-    "copy-paste": "^1.5.3",
+    "clipboardy": "2.3.0",
     "enquirer": "^2.4.1"
   },
   "peerDependencies": {

--- a/packages/ethernaut-ui/src/internal/make-interactive.js
+++ b/packages/ethernaut-ui/src/internal/make-interactive.js
@@ -5,7 +5,7 @@ const output = require('ethernaut-common/src/ui/output')
 const collectArguments = require('./collect-args')
 const toCliSyntax = require('ethernaut-common/src/ui/syntax')
 const getTaskUsage = require('ethernaut-common/src/tasks/usage')
-const { copy } = require('copy-paste')
+const clipboardy = require('clipboardy')
 
 let _hre
 
@@ -93,7 +93,7 @@ function makeInteractive(task) {
       // If parameters were collected, print out the call
       if (Object.values(collectedArgs).length > 0) {
         const msg = toCliSyntax(task, args)
-        copy(msg)
+        clipboardy.writeSync(msg)
         output.info(`Autocompleted: ${msg} (copied to clipboard)`)
       }
     }


### PR DESCRIPTION
Module [copy-paste](https://www.npmjs.com/package/copy-paste) throws an error if xclip is not installed
```
? Pick a task or scope …  Error: spawn xclip ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at processTicksAndRejections (node:internal/process/task_queues:82:21)
```
Easy fix is to replace it with the more popular [clipboardy](https://www.npmjs.com/package/clipboardy). 
Note version 2.3.0 has to be used, since the package is [pure ESM](https://github.com/sindresorhus/clipboardy/releases/tag/v3.0.0) starting from version 3.0.0

Also, Clipboardy doesnt work in a headless environment: 
https://github.com/sindresorhus/clipboardy/issues/63#issuecomment-666303601    

I am using `xvfb` to provide a virtual display when running tests.