### PR TITLE
Checks if a contract address meets known token standards

### DIFF
--- a/packages/ethernaut-interact/README.md
+++ b/packages/ethernaut-interact/README.md
@@ -41,6 +41,7 @@ This plugin adds the following tasks:
 - logs Finds logs emitted by a contract
 - send Sends ether to an address
 - token Interacts with any ERC20 token
+- standards Checks if a contract address meets known token standards
 
 ## Environment extensions
 

--- a/packages/ethernaut-interact/src/tasks/standards.js
+++ b/packages/ethernaut-interact/src/tasks/standards.js
@@ -54,9 +54,24 @@ async function checkERC20(address, hre) {
   try {
     const contract = await getContract('erc20', address, hre)
 
-    // Check the existence of ERC-20 functions without state changes
+    // Check the existence of key ERC-20 functions
     await contract.totalSupply()
     await contract.balanceOf(address)
+
+    // Additional checks for ERC-20 functions using their function signatures
+    const functionsToCheck = [
+      'transfer',
+      'approve',
+      'allowance',
+      'transferFrom',
+    ]
+
+    // Check if these key ERC-20 functions exist in the contract
+    for (const fn of functionsToCheck) {
+      if (!contract.interface.getFunction(fn)) {
+        return false // If any function is missing, it's not ERC-20 compliant
+      }
+    }
 
     return true
   } catch (err) {

--- a/packages/ethernaut-interact/src/tasks/standards.js
+++ b/packages/ethernaut-interact/src/tasks/standards.js
@@ -1,0 +1,101 @@
+const output = require('ethernaut-common/src/ui/output')
+const types = require('ethernaut-common/src/validation/types')
+const { getContract } = require('../internal/get-contract')
+
+require('../scopes/interact')
+  .task('standards', 'Checks if a contract address meets known token standards')
+  .addPositionalParam(
+    'address',
+    'The contract address to check',
+    undefined,
+    types.address,
+  )
+  .setAction(async ({ address }, hre) => {
+    try {
+      const isERC165Supported = await checkERC165Support(address, hre)
+      const erc20 = await checkERC20(address, hre)
+      const erc721Support = isERC165Supported
+        ? await checkERC721(address, hre)
+        : { erc721: false, metadata: false }
+      const erc1155Support = isERC165Supported
+        ? await checkERC1155(address, hre)
+        : { erc1155: false, metadata: false }
+
+      let str = ''
+      str += `Address: ${address}\n`
+      str += 'Token Standards:\n'
+      str += `  ERC-165 Supported: ${isERC165Supported ? 'Yes' : 'No'}\n`
+      str += `  ERC-20: ${erc20 ? 'Yes' : 'No'}\n`
+
+      // Always show ERC-721 status
+      str += `  ERC-721: ${erc721Support.erc721 ? 'Yes' : 'No'}\n`
+      str += `    ERC-721 Metadata: ${erc721Support.metadata ? 'Yes' : 'No'}\n`
+
+      // Always show ERC-1155 status
+      str += `  ERC-1155: ${erc1155Support.erc1155 ? 'Yes' : 'No'}\n`
+      str += `    ERC-1155 Metadata: ${erc1155Support.metadata ? 'Yes' : 'No'}\n`
+
+      return output.resultBox(str)
+    } catch (err) {
+      return output.errorBox(err)
+    }
+  })
+
+async function checkERC165Support(address, hre) {
+  try {
+    const contract = await getContract('erc165', address, hre)
+    return await contract.supportsInterface('0x01ffc9a7') // ERC-165 interface ID
+  } catch (err) {
+    return false
+  }
+}
+
+async function checkERC20(address, hre) {
+  try {
+    const contract = await getContract('erc20', address, hre)
+
+    // Check the existence of ERC-20 functions without state changes
+    await contract.totalSupply()
+    await contract.balanceOf(address)
+
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
+async function checkERC721(address, hre) {
+  try {
+    const contract = await getContract('erc721', address, hre)
+
+    // Check if the contract supports the ERC-721 interface ID using ERC-165
+    const supportsInterface = await contract.supportsInterface('0x80ac58cd') // ERC-721 interface ID
+    if (!supportsInterface) return false
+
+    // Optionally, check if the contract supports ERC-721 Metadata extension
+    const supportsMetadata = await contract.supportsInterface('0x5b5e139f') // ERC-721 Metadata interface ID
+
+    // Return both ERC-721 and metadata support statuses
+    return { erc721: supportsInterface, metadata: supportsMetadata }
+  } catch (err) {
+    return false
+  }
+}
+
+async function checkERC1155(address, hre) {
+  try {
+    const contract = await getContract('erc1155', address, hre)
+
+    // Check if the contract supports the ERC-1155 interface ID using ERC-165
+    const supportsInterface = await contract.supportsInterface('0xd9b67a26') // ERC-1155 interface ID
+    if (!supportsInterface) return false
+
+    // Optionally, check if the contract supports ERC-1155 Metadata URI extension
+    const supportsMetadata = await contract.supportsInterface('0x0e89341c') // ERC-1155 Metadata URI interface ID
+
+    // Return both ERC-1155 and metadata support statuses
+    return { erc1155: supportsInterface, metadata: supportsMetadata }
+  } catch (err) {
+    return false
+  }
+}

--- a/packages/ethernaut-interact/test/fixture-projects/basic-project/contracts/ERC1155.sol
+++ b/packages/ethernaut-interact/test/fixture-projects/basic-project/contracts/ERC1155.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import './ERC165.sol';
+
+/// @title ERC1155 Interface
+interface IERC1155 is IERC165 {
+    event TransferSingle(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256 id,
+        uint256 value
+    );
+
+    function balanceOf(
+        address account,
+        uint256 id
+    ) external view returns (uint256);
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount
+    ) external;
+}
+
+contract ERC1155 is ERC165, IERC1155 {
+    mapping(uint256 => mapping(address => uint256)) private _balances;
+
+    constructor() {
+        _registerInterface(0xd9b67a26); // ERC-1155 Interface ID
+    }
+
+    function balanceOf(
+        address account,
+        uint256 id
+    ) public view override returns (uint256) {
+        return _balances[id][account];
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount
+    ) external override {
+        require(to != address(0), 'ERC1155: transfer to the zero address');
+        require(_balances[id][from] >= amount, 'ERC1155: insufficient balance');
+
+        _balances[id][from] -= amount;
+        _balances[id][to] += amount;
+
+        emit TransferSingle(msg.sender, from, to, id, amount);
+    }
+
+    function _mint(address to, uint256 id, uint256 amount) internal {
+        require(to != address(0), 'ERC1155: mint to the zero address');
+        _balances[id][to] += amount;
+
+        emit TransferSingle(msg.sender, address(0), to, id, amount);
+    }
+}

--- a/packages/ethernaut-interact/test/fixture-projects/basic-project/contracts/ERC165.sol
+++ b/packages/ethernaut-interact/test/fixture-projects/basic-project/contracts/ERC165.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title ERC165 Interface
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+contract ERC165 is IERC165 {
+    mapping(bytes4 => bool) private _supportedInterfaces;
+
+    constructor() {
+        // Register ERC165 itself
+        _registerInterface(0x01ffc9a7);
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external view override returns (bool) {
+        return _supportedInterfaces[interfaceId];
+    }
+
+    function _registerInterface(bytes4 interfaceId) internal {
+        _supportedInterfaces[interfaceId] = true;
+    }
+}

--- a/packages/ethernaut-interact/test/fixture-projects/basic-project/contracts/ERC721.sol
+++ b/packages/ethernaut-interact/test/fixture-projects/basic-project/contracts/ERC721.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import './ERC165.sol';
+
+/// @title ERC721 Interface
+interface IERC721 is IERC165 {
+    event Transfer(
+        address indexed from,
+        address indexed to,
+        uint256 indexed tokenId
+    );
+    event Approval(
+        address indexed owner,
+        address indexed approved,
+        uint256 indexed tokenId
+    );
+
+    function balanceOf(address owner) external view returns (uint256 balance);
+
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+
+    function transferFrom(address from, address to, uint256 tokenId) external;
+}
+
+contract ERC721 is ERC165, IERC721 {
+    mapping(uint256 => address) private _owners;
+    mapping(address => uint256) private _balances;
+    mapping(uint256 => address) private _tokenApprovals;
+
+    constructor() {
+        _registerInterface(0x80ac58cd); // ERC-721 Interface ID
+    }
+
+    function balanceOf(
+        address owner
+    ) external view override returns (uint256 balance) {
+        require(
+            owner != address(0),
+            'ERC721: address zero is not a valid owner'
+        );
+        return _balances[owner];
+    }
+
+    function ownerOf(
+        uint256 tokenId
+    ) external view override returns (address owner) {
+        owner = _owners[tokenId];
+        require(owner != address(0), 'ERC721: invalid token ID');
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external override {
+        require(
+            from == _owners[tokenId],
+            'ERC721: transfer of token that is not own'
+        );
+        require(to != address(0), 'ERC721: transfer to the zero address');
+
+        _balances[from] -= 1;
+        _balances[to] += 1;
+        _owners[tokenId] = to;
+
+        emit Transfer(from, to, tokenId);
+    }
+
+    function _mint(address to, uint256 tokenId) internal {
+        require(to != address(0), 'ERC721: mint to the zero address');
+        require(_owners[tokenId] == address(0), 'ERC721: token already minted');
+
+        _balances[to] += 1;
+        _owners[tokenId] = to;
+
+        emit Transfer(address(0), to, tokenId);
+    }
+}

--- a/packages/ethernaut-interact/test/tasks/standards.test.js
+++ b/packages/ethernaut-interact/test/tasks/standards.test.js
@@ -1,0 +1,87 @@
+const { Terminal } = require('ethernaut-common/src/test/terminal')
+
+describe('standards', function () {
+  const terminal = new Terminal()
+
+  describe('when interacting with various contracts', function () {
+    let sample, testToken, simpleERC721, simpleERC1155, simpleERC165
+
+    before('deploy all test contracts', async function () {
+      const Sample = await hre.ethers.getContractFactory('Sample')
+      sample = await Sample.deploy()
+
+      const TestToken = await hre.ethers.getContractFactory('TestToken')
+      testToken = await TestToken.deploy('Test Token', 'TEST', 16)
+
+      const SimpleERC721 = await hre.ethers.getContractFactory('ERC721')
+      simpleERC721 = await SimpleERC721.deploy()
+
+      const SimpleERC1155 = await hre.ethers.getContractFactory('ERC1155')
+
+      simpleERC1155 = await SimpleERC1155.deploy()
+
+      const SimpleERC165 = await hre.ethers.getContractFactory('ERC165')
+      simpleERC165 = await SimpleERC165.deploy()
+    })
+
+    describe('when checking Sample contract (non-compliant)', function () {
+      it('returns false for all standards', async function () {
+        await terminal.run(
+          `hardhat interact standards  ${await sample.getAddress()}`,
+        )
+        terminal.has('ERC-165 Supported: No')
+        terminal.has('ERC-20: No')
+        terminal.has('ERC-721: No')
+        terminal.has('ERC-1155: No')
+      })
+    })
+
+    describe('when checking TestToken (ERC-20)', function () {
+      it('returns true for ERC-20 and false for others', async function () {
+        await terminal.run(
+          `hardhat interact standards  ${await testToken.getAddress()}`,
+        )
+        terminal.has('ERC-165 Supported: No')
+        terminal.has('ERC-20: Yes')
+        terminal.has('ERC-721: No')
+        terminal.has('ERC-1155: No')
+      })
+    })
+
+    describe('when checking SimpleERC721 (ERC-721)', function () {
+      it('returns true for ERC-721 and ERC-165, false for others', async function () {
+        await terminal.run(
+          `hardhat interact standards  ${await simpleERC721.getAddress()}`,
+        )
+        terminal.has('ERC-165 Supported: Yes')
+        terminal.has('ERC-20: No')
+        terminal.has('ERC-721: Yes')
+        terminal.has('ERC-1155: No')
+      })
+    })
+
+    describe('when checking SimpleERC1155 (ERC-1155)', function () {
+      it('returns true for ERC-1155 and ERC-165, false for others', async function () {
+        await terminal.run(
+          `hardhat interact standards  ${await simpleERC1155.getAddress()}`,
+        )
+        terminal.has('ERC-165 Supported: Yes')
+        terminal.has('ERC-20: No')
+        terminal.has('ERC-721: No')
+        terminal.has('ERC-1155: Yes')
+      })
+    })
+
+    describe('when checking SimpleERC165 (ERC-165 only)', function () {
+      it('returns true for ERC-165 and false for others', async function () {
+        await terminal.run(
+          `hardhat interact standards  ${await simpleERC165.getAddress()}`,
+        )
+        terminal.has('ERC-165 Supported: Yes')
+        terminal.has('ERC-20: No')
+        terminal.has('ERC-721: No')
+        terminal.has('ERC-1155: No')
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Add Interact task that checks if a contract address meets known token standards

**Usage:**

#### 1. **Non-compliant contract**

```bash
ethernaut interact standards 0x63f38cBE5E820cC6833aED046bd4cc59e7a96dd5
╭ Result ─────────────────────────────────────────────────╮
│                                                         │
│   Address: 0x63f38cBE5E820cC6833aED046bd4cc59e7a96dd5   │
│   Token Standards:                                      │
│     ERC-165 Supported: No                               │
│     ERC-20: No                                          │
│     ERC-721: No                                         │
│       ERC-721 Metadata: No                              │
│     ERC-1155: No                                        │
│       ERC-1155 Metadata: No				  │	
```

#### 2. **ERC-20 contract**

```bash
ethernaut interact standards 0x14d9204a21d422BEF173Bc5A1DaA7402a999B66F
╭ Result ─────────────────────────────────────────────────╮
│                                                         │
│   Address: 0x14d9204a21d422BEF173Bc5A1DaA7402a999B66F   │
│   Token Standards:                                      │
│     ERC-165 Supported: No                               │
│     ERC-20: Yes                                         │
│     ERC-721: No                                         │
│       ERC-721 Metadata: No                              │
│     ERC-1155: No                                        │
│       ERC-1155 Metadata: No                             │
```

#### 3. **ERC-721 contract**

```bash
ethernaut interact standards 0xEa2D39869dd9af7d301945a23Bf6E6BF8B03723A
╭ Result ─────────────────────────────────────────────────╮
│                                                         │
│   Address: 0xEa2D39869dd9af7d301945a23Bf6E6BF8B03723A   │
│   Token Standards:                                      │
│     ERC-165 Supported: Yes                              │
│     ERC-20: No                                          │
│     ERC-721: Yes                                        │
│       ERC-721 Metadata: Yes                             │
│     ERC-1155: No                                        │
│       ERC-1155 Metadata: No                             │
```

#### 4. **ERC-1155 contract**

```bash
ethernaut interact standards 0x24b7013730878F0C6b3333b1eAAAEa334cfdd846
╭ Result ─────────────────────────────────────────────────╮
│                                                         │
│   Address: 0x24b7013730878F0C6b3333b1eAAAEa334cfdd846   │
│   Token Standards:                                      │
│     ERC-165 Supported: Yes                              │
│     ERC-20: No                                          │
│     ERC-721: No                                         │
│       ERC-721 Metadata: No                              │
│     ERC-1155: Yes                                       │
│       ERC-1155 Metadata: Yes                            │
```
